### PR TITLE
Bugfix: make extension_url contain correct url in all cases

### DIFF
--- a/extensions/customizer/extension_customizer.php
+++ b/extensions/customizer/extension_customizer.php
@@ -81,6 +81,12 @@ if( !class_exists( 'ReduxFramework_extension_customizer' ) ) {
         if ( empty( $this->extension_dir ) ) {
           $this->extension_dir = trailingslashit( str_replace( '\\', '/', dirname( __FILE__ ) ) );
           $this->extension_url = site_url( str_replace( trailingslashit( str_replace( '\\', '/', ABSPATH ) ), '', $this->extension_dir ) );
+
+          // Easier to read and less buggy way to find out correct url, but applicable
+          // only if wp-content found. Othewise fall back to old URL detection code.
+          if ( preg_match("/wp-content\/(.*)/", $this->extension_dir, $match) ) {
+            $this->extension_url = site_url('/wp-content/'.$match[1]);
+          }
         }
 
       }

--- a/extensions/edd/extension_edd.php
+++ b/extensions/edd/extension_edd.php
@@ -53,8 +53,14 @@ if( !class_exists( 'ReduxFramework_extension_edd' ) ) {
         if ( empty( $this->extension_dir ) ) {
           $this->extension_dir = trailingslashit( str_replace( '\\', '/', dirname( __FILE__ ) ) );
           $this->extension_url = site_url( str_replace( trailingslashit( str_replace( '\\', '/', ABSPATH ) ), '', $this->extension_dir ) );
+
+          // Easier to read and less buggy way to find out correct url, but applicable
+          // only if wp-content found. Othewise fall back to old URL detection code.
+          if ( preg_match("/wp-content\/(.*)/", $this->extension_dir, $match) ) {
+            $this->extension_url = site_url('/wp-content/'.$match[1]);
+          }
         }
-        
+
 
         if ( isset( $parent->args['edd'] ) && !empty( $parent->args['edd'] ) ) {
           // Create defaults array


### PR DESCRIPTION
The old code populated _extension_url with contents like
https://example.org/var/www/sites/htdocs/wp-content/plugins/redux-framework/
-> ReduxCore/inc/extensions/customizer/

New implementation is does not mind if Redux is embedded in a theme or plugin,
supports having WordPress installed in any directory and to avoid future bugs:
the new code is clean and easy to read.
